### PR TITLE
Operating Requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,15 +111,16 @@ def make_request():
 
 @app.route("/submit-request", methods=["POST"])
 def check_request():
+    title = request.form["title"]
     requiredmoney = request.form["amount"]
-    reason = request.form["dscrp"]
-    usernameAttempt = request.form["uname"]
+    usernameAttempt = request.form["username"]
     passwordAttempt = request.form["psw"]
+    reason = request.form["description"]
     result = authenticate(usernameAttempt, passwordAttempt)
     if result:    
         ID = get_id(usernameAttempt)
-        open_request(ID,requiredmoney,reason)
-        return render_template("feed.html")
+        open_request(ID,requiredmoney,reason,title)
+        return render_template("loginsuccess.html")
     else: 
         return render_template("loginFailure.html") 
 

--- a/schema.py
+++ b/schema.py
@@ -96,6 +96,7 @@ class Request(Base, IdPrimaryKeyMixin, DateTimeMixin):
     amount_filled = Column(Float, default=0.0) #How much money has been raised
     anon = Column(Boolean, default=True) #Will the request be posted anonymously
     filled = Column(Boolean, default=False) #After the request is filled, it no longer needs to be donated to
+    approved = Column(Boolean, default=False) #admin approval is needed for the request to be shown
     
     def __repr__(self):
         ret = "<ID: %d, Requested: %d, Filled: %d, Title: %s>" % (


### PR DESCRIPTION
Enabled the database to store requests. Sends successful and failed attempts to the login success and login failure pages respectively, but they are to be only used as placeholders until we have a more specific confirmation page.